### PR TITLE
MultiPageResultSet: fix bug w/r/t intermediate zero-row pages

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/MultiPageResultSet.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/MultiPageResultSet.java
@@ -95,7 +95,7 @@ public class MultiPageResultSet implements ResultSet {
     }
 
     private void maybeMoveToNextPage() {
-      if (!currentRows.hasNext() && currentPage.hasMorePages()) {
+      while (!currentRows.hasNext() && currentPage.hasMorePages()) {
         BlockingOperation.checkNotDriverThread();
         AsyncResultSet nextPage =
             CompletableFutures.getUninterruptibly(currentPage.fetchNextPage());


### PR DESCRIPTION
Zero row pages can sometimes happen, for example when using "filtering". The iterator has a logic bug which makes it end too early, when encountering this.

Fix this issue with minimal code changes and add associated unit tests.